### PR TITLE
disabled started tests regeneration

### DIFF
--- a/app/controllers/member_tests_controller.rb
+++ b/app/controllers/member_tests_controller.rb
@@ -40,7 +40,11 @@ class MemberTestsController < ApplicationController
 
   def regenerate
     @member_test.regerenate!
-    redirect_to @member_test, notice: 'Member test was successfully regenerated.'
+    if @member_test.status == 'started'
+      redirect_back fallback_location: root_path, notice: 'Cannot regenerate started tests'
+    else 
+      redirect_to @member_test, notice: 'Member test was successfully regenerated.'
+    end
   end
 
   def destroy
@@ -48,10 +52,16 @@ class MemberTestsController < ApplicationController
     redirect_to member_tests_url, notice: 'Member test was successfully destroyed.'
   end
 
-  def pass_form; end
+  def pass_form
+    if @member_test.status == 'draft'
+      @member_test.update(status: 'started');
+    end
+  end
 
   def pass
     if @member_test.update(pass_params)
+      @member_test.check_results
+      @member_test.save
       redirect_to @member_test, notice: 'Member test was completed.'
     else
       render :pass_form

--- a/app/models/member_test.rb
+++ b/app/models/member_test.rb
@@ -20,7 +20,7 @@ class MemberTest < ApplicationRecord
   validates :test_id, uniqueness: { scope: :member_id }
   
   after_create :populate_member_test_questions
-  #before_update :check_results
+  before_update :check_results
 
   accepts_nested_attributes_for :member_test_questions, allow_destroy: true
   
@@ -43,12 +43,14 @@ class MemberTest < ApplicationRecord
     return right_count
   end
 
-  def check_results
-    right_count = count_rights
-    self.status = right_count >= test.pass_count ? :passed : :failed
-  end
-
   private
+
+  def check_results
+    if self.status_was === 'started'
+      right_count = count_rights
+      self.status = right_count >= test.pass_count ? :passed : :failed
+    end
+  end
 
   def populate_member_test_questions
     test.questions.order("RANDOM()").limit(test.questions_count).each do |question|

--- a/app/models/member_test.rb
+++ b/app/models/member_test.rb
@@ -15,19 +15,19 @@ class MemberTest < ApplicationRecord
 
   has_many :member_test_questions, dependent: :destroy
 
-  enum status: { started: "started", passed: "passed", failed: "failed" }
+  enum status: { draft: "draft", started: "started", passed: "passed", failed: "failed" }
 
   validates :test_id, uniqueness: { scope: :member_id }
   
   after_create :populate_member_test_questions
-  before_update :check_results
+  #before_update :check_results
 
   accepts_nested_attributes_for :member_test_questions, allow_destroy: true
   
 
   def regerenate!
     member_test_questions.destroy_all
-    update_column(:status, :started)
+    update_column(:status, :draft)
     populate_member_test_questions
   end
 
@@ -43,6 +43,11 @@ class MemberTest < ApplicationRecord
     return right_count
   end
 
+  def check_results
+    right_count = count_rights
+    self.status = right_count >= test.pass_count ? :passed : :failed
+  end
+
   private
 
   def populate_member_test_questions
@@ -52,11 +57,5 @@ class MemberTest < ApplicationRecord
         mtq.member_test_question_answers.create!(answer_id: x, label: ('A'..'Z').to_a[i])
       end
     end
-  end
-
-
-  def check_results
-    right_count = count_rights
-    self.status = right_count >= test.pass_count ? :passed : :failed
   end
 end

--- a/app/views/member_tests/index.slim
+++ b/app/views/member_tests/index.slim
@@ -25,6 +25,7 @@
             td.table-actions
               = link_to 'Print', member_test_path(member_test, format: :pdf), target: "_blank", class: 'btn btn--black btn--inline'
               = link_to 'Pass', pass_form_member_test_path(member_test), class: 'btn btn--black btn--inline'
-              = link_to 'Regenerate', regenerate_member_test_path(member_test), class: 'btn btn--white btn--inline'
+              - if member_test.status != 'started'
+                = link_to 'Regenerate', regenerate_member_test_path(member_test), class: 'btn btn--white btn--inline'
               = link_to 'Destroy', member_test, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn--white btn--inline'
   <br>

--- a/app/views/member_tests/index.slim
+++ b/app/views/member_tests/index.slim
@@ -25,7 +25,7 @@
             td.table-actions
               = link_to 'Print', member_test_path(member_test, format: :pdf), target: "_blank", class: 'btn btn--black btn--inline'
               = link_to 'Pass', pass_form_member_test_path(member_test), class: 'btn btn--black btn--inline'
-              - if member_test.status != 'started'
+              - unless member_test.started?
                 = link_to 'Regenerate', regenerate_member_test_path(member_test), class: 'btn btn--white btn--inline'
               = link_to 'Destroy', member_test, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn--white btn--inline'
   <br>

--- a/app/views/member_tests/show.slim
+++ b/app/views/member_tests/show.slim
@@ -1,15 +1,22 @@
 = render "layouts/show_page" do
   .show 
     .show--content
-      .show--content--title class="#{@member_test.status == 'failed' ? 'failed_pass' : 'success_pass'}"
-        h1
-          = @member_test.status == 'started' ? 'Good luck' : @member_test.status == 'passed' ? 'Winner winner chicken dinner' : 'Better luck next time'
-        - if @member_test.status != 'started'
+      - status = @member_test.status
+      .show--content--title class="#{status == 'failed' ? 'failed_pass' : 'success_pass'}"
+        h1          
+          - if status == 'passed'
+            = 'Winner winner chicken dinner'
+          - elsif status == 'failed'
+            = 'Better luck next time'
+          - else
+            = 'Good luck'
+        - if status == 'passed' || status === 'failed'
           p Your result is #{@member_test.count_rights}/#{@member_test.test.questions_count}
       .actions
         = link_to 'Pass', pass_form_member_test_path(@member_test), class: 'btn btn--secondary'
-        = link_to 'Regenerate', regenerate_member_test_path(@member_test), class: 'btn btn--secondary'
-        = link_to 'Print', member_test_path(@member_test, format: :pdf), class: 'btn btn--primary', target: "_blank"
+        - if status != 'started'
+          = link_to 'Regenerate', regenerate_member_test_path(@member_test), class: 'btn btn--secondary'
+        = link_to 'Print', member_test_path(@member_test, format: :pdf), class: 'btn btn--primary', target: '_blank'
       .questions
         .questions--header
           h1 In details
@@ -18,7 +25,7 @@
             .question-container
               .question--label
                 strong = "Q#{index+1}"
-                - if @member_test.status != 'started'
+                - if status == 'passed' || status == 'failed'
                   = image_tag (@member_test.is_question_right(member_test_question)? 'check.svg' : 'cross.svg') 
               .padding
                 .question

--- a/app/views/member_tests/show.slim
+++ b/app/views/member_tests/show.slim
@@ -1,20 +1,19 @@
 = render "layouts/show_page" do
   .show 
     .show--content
-      - status = @member_test.status
-      .show--content--title class="#{status == 'failed' ? 'failed_pass' : 'success_pass'}"
+      .show--content--title class="#{@member_test.failed? ? 'failed_pass' : 'success_pass'}"
         h1          
-          - if status == 'passed'
+          - if @member_test.passed?
             = 'Winner winner chicken dinner'
-          - elsif status == 'failed'
+          - elsif @member_test.failed?
             = 'Better luck next time'
           - else
             = 'Good luck'
-        - if status == 'passed' || status === 'failed'
+        - if @member_test.passed? || @member_test.failed?
           p Your result is #{@member_test.count_rights}/#{@member_test.test.questions_count}
       .actions
         = link_to 'Pass', pass_form_member_test_path(@member_test), class: 'btn btn--secondary'
-        - if status != 'started'
+        - unless @member_test.started?
           = link_to 'Regenerate', regenerate_member_test_path(@member_test), class: 'btn btn--secondary'
         = link_to 'Print', member_test_path(@member_test, format: :pdf), class: 'btn btn--primary', target: '_blank'
       .questions
@@ -25,7 +24,7 @@
             .question-container
               .question--label
                 strong = "Q#{index+1}"
-                - if status == 'passed' || status == 'failed'
+                - if @member_test.passed? || @member_test.failed?
                   = image_tag (@member_test.is_question_right(member_test_question)? 'check.svg' : 'cross.svg') 
               .padding
                 .question

--- a/db/migrate/20200831140304_change_member_tests_status_default_to_draft.rb
+++ b/db/migrate/20200831140304_change_member_tests_status_default_to_draft.rb
@@ -1,0 +1,5 @@
+class ChangeMemberTestsStatusDefaultToDraft < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :member_tests, :status, from: :started, to: :draft
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_12_193004) do
+ActiveRecord::Schema.define(version: 2020_08_31_140304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_193004) do
   end
 
   create_table "member_tests", force: :cascade do |t|
-    t.string "status", default: "started", null: false
+    t.string "status", default: "draft", null: false
     t.bigint "member_id"
     t.bigint "test_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Added "draft" status, disabled regeneration for started tests.

"draft" -> "started" after click on "pass"